### PR TITLE
Limit commits to 500

### DIFF
--- a/.changes/limit-commits.md
+++ b/.changes/limit-commits.md
@@ -1,0 +1,5 @@
+---
+"strand": patch:fix
+---
+
+Limit the number of commits loaded to 500

--- a/src-tauri/src/commands/get_graph.rs
+++ b/src-tauri/src/commands/get_graph.rs
@@ -23,6 +23,7 @@ pub async fn get_graph(app_handle: tauri::AppHandle) -> CommandResult<Vec<Commit
     let commits = GitCommand::new("log")
         .arg(format!("--format={format}\x01"))
         .arg("--all")
+        .arg("-500") // Limit to 500 commits
         .run(&app_handle, GitCommandType::Query)
         .await?;
 


### PR DESCRIPTION
Until pagination/virtualisation is implemented, limit the number of commits fetched to 500 to prevent crashing the UI.