### PR TITLE
View working changes file counts

### DIFF
--- a/.changes/show-changed-files.md
+++ b/.changes/show-changed-files.md
@@ -1,0 +1,5 @@
+---
+"strand": minor:feat
+---
+
+Show changed files status at the top of the graph

--- a/src-tauri/src/commands/get_changed_files.rs
+++ b/src-tauri/src/commands/get_changed_files.rs
@@ -17,10 +17,7 @@ pub async fn get_changed_files(
         .run(&app_handle, GitCommandType::Query)
         .await?;
 
-    let items = items
-        .strip_suffix('\x00')
-        .ok_or(CommandError::Parse("Failed to strip files suffix".into()))?
-        .split('\x00');
+    let items = items.split('\x00').filter(|item| !item.is_empty());
 
     let mut staged_files = Vec::new();
     let mut unstaged_files = Vec::new();

--- a/src-tauri/src/commands/get_changed_files.rs
+++ b/src-tauri/src/commands/get_changed_files.rs
@@ -1,0 +1,133 @@
+use crate::{
+    cli::GitCommand,
+    db::GitCommandType,
+    structures::{file::File, file_status::FileStatus, hash::GitHash},
+};
+
+use super::{CommandError, CommandResult};
+
+#[tauri::command]
+#[specta::specta]
+pub async fn get_changed_files(
+    app_handle: tauri::AppHandle,
+) -> CommandResult<(Vec<File>, Vec<File>)> {
+    let items = GitCommand::new("status")
+        .arg("-z") // Separate commits with NULs for parsing
+        .arg("--porcelain=2") // Use stable parsable porcelain format
+        .run(&app_handle, GitCommandType::Query)
+        .await?;
+
+    let items = items
+        .strip_suffix('\x00')
+        .ok_or(CommandError::Parse("Failed to strip files suffix".into()))?
+        .split('\x00');
+
+    let mut staged_files = Vec::new();
+    let mut unstaged_files = Vec::new();
+    for item in items {
+        let (line_type, item) = item
+            .split_once(' ')
+            .ok_or(CommandError::Parse("Failed to split item".into()))?;
+
+        match line_type {
+            "1" | "2" | "u" => {
+                let (status, item) = item
+                    .split_once(' ')
+                    .ok_or(CommandError::Parse("Failed to split item".into()))?;
+                let status: Vec<Option<FileStatus>> = status
+                    .chars()
+                    .map(|l| match l {
+                        '.' => None,
+                        x => x.try_into().ok(),
+                    })
+                    .collect();
+
+                let mut parts = item.split_ascii_whitespace().skip(4);
+                if line_type == "u" {
+                    parts.next();
+                }
+                let head_hash = parts
+                    .next()
+                    .ok_or(CommandError::Parse("Failed to get head hash".into()))?;
+                let index_hash = parts
+                    .next()
+                    .ok_or(CommandError::Parse("Failed to get index hash".into()))?;
+                let (score, dst_path, path) = match line_type {
+                    "1" => (
+                        None,
+                        None,
+                        parts
+                            .next()
+                            .ok_or(CommandError::Parse("Failed to get path for type 1".into()))?,
+                    ),
+                    "2" => (
+                        parts
+                            .next()
+                            .ok_or(CommandError::Parse("Failed to score for type 2".into()))?
+                            .split_at(1)
+                            .1
+                            .parse()
+                            .ok(),
+                        Some(parts.next().ok_or(CommandError::Parse(
+                            "Failed to get dst_path for type 2".into(),
+                        ))?),
+                        parts
+                            .next()
+                            .ok_or(CommandError::Parse("Failed to get path for type 2".into()))?,
+                    ),
+                    "u" => (
+                        None,
+                        None,
+                        parts
+                            .nth(1)
+                            .ok_or(CommandError::Parse("Failed to get path for type u".into()))?,
+                    ),
+                    _ => unreachable!(),
+                };
+
+                if let Some(staged_status) = &status[0] {
+                    staged_files.push(File {
+                        src_hash: GitHash::from_optional(head_hash).map_err(|_err| {
+                            CommandError::Parse("Failed to parse head hash".into())
+                        })?,
+                        dst_hash: GitHash::from_optional(index_hash).map_err(|_err| {
+                            CommandError::Parse("Failed to parse index hash".into())
+                        })?,
+                        status: *staged_status,
+                        score,
+                        src_path: path.into(),
+                        dst_path: dst_path.map(|s| s.into()),
+                    });
+                }
+
+                if let Some(unstaged_status) = &status[1] {
+                    unstaged_files.push(File {
+                        src_hash: GitHash::from_optional(head_hash).map_err(|_err| {
+                            CommandError::Parse("Failed to parse head hash".into())
+                        })?,
+                        dst_hash: GitHash::from_optional(index_hash).map_err(|_err| {
+                            CommandError::Parse("Failed to parse index hash".into())
+                        })?,
+                        status: *unstaged_status,
+                        score,
+                        src_path: path.into(),
+                        dst_path: dst_path.map(|s| s.into()),
+                    });
+                }
+            }
+            // Untracked
+            "?" => unstaged_files.push(File {
+                src_hash: None,
+                dst_hash: None,
+                status: FileStatus::Added,
+                score: None,
+                src_path: item.into(),
+                dst_path: None,
+            }),
+            // Ignore unknown line types
+            _ => {}
+        }
+    }
+
+    Ok((unstaged_files, staged_files))
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@ use crate::cli::GitError;
 
 pub mod add_repository_from_path;
 pub mod get_branches;
+pub mod get_changed_files;
 pub mod get_commit_files;
 pub mod get_file_diff;
 pub mod get_git_command_log;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -30,6 +30,7 @@ fn main() {
                 commands::get_graph::get_graph,
                 commands::get_commit_files::get_commit_files,
                 commands::get_file_diff::get_file_diff,
+                commands::get_changed_files::get_changed_files,
             ))
             .events(collect_events!(GitCommandEvent))
             .config(ExportConfig::new().bigint(specta::ts::BigIntExportBehavior::Number));

--- a/src-tauri/src/structures/file_status.rs
+++ b/src-tauri/src/structures/file_status.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 use specta::Type;
 
-#[derive(Debug, Serialize, Type)]
+#[derive(Debug, Serialize, Type, Clone, Copy)]
 #[repr(u8)]
 pub enum FileStatus {
     /// Addition of a file

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -83,6 +83,14 @@ try {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+async getChangedFiles() : Promise<Result<[File[], File[]], string>> {
+try {
+    return { status: "ok", data: await TAURI_INVOKE("get_changed_files") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 

--- a/src/components/CommitDetails/Stats.tsx
+++ b/src/components/CommitDetails/Stats.tsx
@@ -3,11 +3,11 @@ import { FileInputIcon, MinusIcon, PencilIcon, PlusIcon } from 'lucide-react'
 import type { File } from '../../bindings'
 import { TooltipContent } from '../UI/Tooltip'
 
-export const CommitStats = ({ files }: { files: File[] }) => {
+export const CommitStats = ({ files, className }: { files: File[]; className?: string }) => {
   const stats = calculateStats(files)
 
   return (
-    <div className="mt-4 mb-1.5">
+    <div className={className}>
       <div className="flex gap-2.5 items-center">
         {stats.modified > 0 && (
           <Tooltip>

--- a/src/components/CommitDetails/index.tsx
+++ b/src/components/CommitDetails/index.tsx
@@ -68,7 +68,7 @@ export const CommitDetails = () => {
 
             {files && (
               <>
-                <CommitStats files={files} />
+                <CommitStats className="mt-4 mb-1.5" files={files} />
 
                 <div className="bg-surface rounded-md flex-1 flex flex-col min-h-0">
                   <div className="overflow-y-auto flex-1 pt-1">

--- a/src/components/Graph/index.tsx
+++ b/src/components/Graph/index.tsx
@@ -16,6 +16,15 @@ export const Graph = () => {
     refetchOnWindowFocus: true,
   })
 
+  const test = useCommandQuery({
+    queryKey: ['status'],
+    queryFn: commands.getChangedFiles,
+    enabled: Boolean(openRepository),
+    refetchOnWindowFocus: true,
+  })
+
+  console.log(test.data)
+
   const [selectedHash, _setSelectedHash] = useAtom(selectedCommitHashAtom)
   const setSelectedFileId = useSetAtom(selectedFileIdAtom)
   const setSelectedHash = (hash: string | null) => {
@@ -72,7 +81,7 @@ export const Graph = () => {
 
   return (
     <div className="overflow-y-auto h-full">
-      <div className="bg-[linear-gradient(color-mix(in_srgb,_var(--color-foreground)_5%,_transparent)_50%,transparent_50%)] [background-size:100%_3.5rem]">
+      <div className="bg-[linear-gradient(color-mix(in_srgb,_rgb(var(--color-foreground))_5%,_transparent)_50%,transparent_50%)] [background-size:100%_3.5rem]">
         {commits?.map((commit) => (
           <CommitRow
             key={commit.hash}

--- a/src/components/Graph/index.tsx
+++ b/src/components/Graph/index.tsx
@@ -4,6 +4,7 @@ import { commands } from '../../bindings'
 import { useOpenRepository } from '../../data/useOpenRepository'
 import { selectedCommitHashAtom, selectedFileIdAtom } from '../../ui-state'
 import { useCommandQuery } from '../../utils/useCommandQuery'
+import { CommitStats } from '../CommitDetails/Stats'
 import { CommitRow } from './CommitRow'
 
 export const Graph = () => {
@@ -16,14 +17,12 @@ export const Graph = () => {
     refetchOnWindowFocus: true,
   })
 
-  const test = useCommandQuery({
+  const { data: changes } = useCommandQuery({
     queryKey: ['status'],
     queryFn: commands.getChangedFiles,
     enabled: Boolean(openRepository),
     refetchOnWindowFocus: true,
   })
-
-  console.log(test.data)
 
   const [selectedHash, _setSelectedHash] = useAtom(selectedCommitHashAtom)
   const setSelectedFileId = useSetAtom(selectedFileIdAtom)
@@ -81,7 +80,21 @@ export const Graph = () => {
 
   return (
     <div className="overflow-y-auto h-full">
-      <div className="bg-[linear-gradient(color-mix(in_srgb,_rgb(var(--color-foreground))_5%,_transparent)_50%,transparent_50%)] [background-size:100%_3.5rem]">
+      <div className="bg-[linear-gradient(transparent_50%,color-mix(in_srgb,rgb(var(--color-foreground))_5%,transparent)_50%)] [background-size:100%_3.5rem]">
+        {((changes?.[0].length ?? 0) > 0 || (changes?.[1].length ?? 0) > 0) && (
+          <div className="h-7 pl-2">
+            <div className="flex items-center w-full h-full outline-none group/commit-row" tabIndex={-1}>
+              <div className="flex items-center h-6 rounded-l-full flex-1 min-w-0 group-hover/commit-row:bg-orange-300/20 dark:group-hover/commit-row:bg-orange-900/20">
+                <div className="h-6 w-6 rounded-full border-orange-400 dark:border-orange-700 border-2 border-dashed shrink-0 bg-surface" />
+
+                <div className="ml-3 bg-surface rounded-md h-5 flex items-center px-1">
+                  <CommitStats files={changes?.flat() ?? []} />
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
         {commits?.map((commit) => (
           <CommitRow
             key={commit.hash}


### PR DESCRIPTION
This PR adds support to view the file status summary for files changed in the working tree or staging area.

Note: this is currently broken and will show an error if there are any renamed files. I've come to the conclusion that my current naive method of parsing the command output is not going to work in the long run so I'll be working to replace it with a more robust system before anything else, likely using `nom`.